### PR TITLE
Fixed type deduction issues in some cases

### DIFF
--- a/compiler/src/mast/lower.rs
+++ b/compiler/src/mast/lower.rs
@@ -780,7 +780,7 @@ impl<'a> Lowerer<'a> {
             }
 
             ExprKind::Return(val) => {
-                self.lower_return(val.as_deref(), subst_map, expected_ty, expr.span)
+                self.lower_return(val.as_deref(), subst_map, expr.span)
             }
             ExprKind::Assign { lhs, op, rhs } => self.lower_assign(lhs, *op, rhs, subst_map),
             ExprKind::GenericInstantiation { .. } => self.lower_generic_instantiation(concrete_ty),
@@ -2233,10 +2233,9 @@ impl<'a> Lowerer<'a> {
         &mut self,
         val: Option<&Expr>,
         subst_map: &HashMap<SymbolId, TypeId>,
-        expected_ty: Option<TypeId>,
         span: Span,
     ) -> MastExprKind {
-        let v = val.map(|e| Box::new(self.lower_expr(e, subst_map, expected_ty)));
+        let v = val.map(|e| Box::new(self.lower_expr(e, subst_map, None)));
         let mut defer_stmts = Vec::new();
 
         // 倒序展开当前作用域栈中所有的 defer

--- a/tests/test2.kn
+++ b/tests/test2.kn
@@ -3,7 +3,13 @@ extern {
     fn printf(format: *u8, ...) i32;
 }
 
+fn fib(src: i64) i64 {
+    if(src < 2) return src;
+    return fib(src - 1) + fib(src - 2);
+}
+
 fn main() i32 {
-    printf("Hello World from Kern %d.%d.%d!\n\0".[0].&, 0, 3, 0);
+    let a = fib(40);
+    printf("%d\n\0".[0].&, a);
     return 0;
 }


### PR DESCRIPTION
- By removing the lower_return contaminant, we ensure that single-statement flow control statements can correctly deduce the function return type.
- Modify test2.kn to test Fibonacci calculations.