### PR TITLE
feat::add --lib and --bin options to init

### DIFF
--- a/tools/craft/src/cli.rs
+++ b/tools/craft/src/cli.rs
@@ -32,6 +32,7 @@ pub enum Command {
     Init {
         path: Option<PathBuf>,
         ui: UiOptions,
+        kind: Option<InitKind>,
     },
     Clean {
         path: Option<PathBuf>,
@@ -105,6 +106,12 @@ pub enum Command {
 pub enum HelpTopic {
     Overview,
     Command(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InitKind {
+    Lib,
+    Bin,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -308,10 +315,41 @@ where
 
     match cmd.as_str() {
         "init" => {
-            let options = parse_command_options(rest, init_option_mode())?;
+            let mut init_bin = false;
+            let mut init_lib = false;
+            let rest: Vec<String> = rest
+                .iter()
+                .filter(|arg| {
+                    if **arg == "--lib" {
+                        init_lib = true;
+                        false
+                    } else if **arg == "--bin" {
+                        init_bin = true;
+                        false
+                    } else {
+                        true
+                    }
+                })
+                .cloned()
+                .collect();
+            if init_bin && init_lib {
+                return Err(Error::Usage(format!(
+                    "Both a library and binary???: {}",
+                    args.join(" ")
+                )))
+            }
+            let mut kind: Option<InitKind> = None;
+            if init_bin {
+                kind = Some(InitKind::Bin);
+            }
+            if init_lib {
+                kind = Some(InitKind::Lib);
+            }
+            let options = parse_command_options(&rest, init_option_mode())?;
             Ok(Command::Init {
                 path: options.path,
                 ui: options.ui,
+                kind,
             })
         }
         "clean" => {

--- a/tools/craft/src/cli.rs
+++ b/tools/craft/src/cli.rs
@@ -336,7 +336,7 @@ where
                 return Err(Error::Usage(format!(
                     "Both a library and binary???: {}",
                     args.join(" ")
-                )))
+                )));
             }
             let mut kind: Option<InitKind> = None;
             if init_bin {

--- a/tools/craft/src/cli/commands.rs
+++ b/tools/craft/src/cli/commands.rs
@@ -22,6 +22,7 @@ use crate::resolver;
 use crate::source::{self, FetchProgress, FetchProgressKind, FetchProgressPhase};
 use crate::style;
 use crate::workspace;
+use crate::cli::InitKind;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -147,7 +148,7 @@ pub(super) fn run_command(command: Command) -> Result<()> {
             println!("{}", super::version_text());
             Ok(())
         }
-        Command::Init { path, ui } => run_init(path, ui),
+        Command::Init { path, ui , kind} => run_init(path, ui, kind),
         Command::Clean { path, ui } => run_clean(path, ui),
         Command::Check {
             path,
@@ -319,11 +320,11 @@ fn run_fmt(path: Option<PathBuf>, ui: super::UiOptions, check: bool) -> Result<(
     Ok(())
 }
 
-fn run_init(path: Option<PathBuf>, ui: super::UiOptions) -> Result<()> {
+fn run_init(path: Option<PathBuf>, ui: super::UiOptions, kind: Option<InitKind>) -> Result<()> {
     let render = Renderer::new(ui);
     let root = resolve_init_root(path.as_deref())?;
     let _workspace_lock = WorkspaceOperationLock::acquire(&root, "init")?;
-    let init = plan_init(&root)?;
+    let init = plan_init(&root, kind)?;
     let created = apply_init_plan(&root, &init)?;
     let manifest_path = root.join("Craft.toml");
     let manifest = Manifest::load(&manifest_path)?;
@@ -1813,6 +1814,7 @@ struct InitPlan {
     test_roots: Vec<String>,
     example_roots: Vec<String>,
     create_main_stub: bool,
+    create_lib_stub: bool,
 }
 
 impl InitPlan {
@@ -1872,7 +1874,7 @@ fn resolve_init_root(path: Option<&Path>) -> Result<PathBuf> {
     fs::canonicalize(&root).map_err(|err| Error::from_io(&root, err))
 }
 
-fn plan_init(root: &Path) -> Result<InitPlan> {
+fn plan_init(root: &Path, kind: Option<InitKind>) -> Result<InitPlan> {
     let manifest_path = root.join("Craft.toml");
     if manifest_path.exists() {
         match Manifest::load(&manifest_path).and_then(|manifest| manifest.validate(&manifest_path))
@@ -1892,17 +1894,25 @@ fn plan_init(root: &Path) -> Result<InitPlan> {
         }
     }
 
-    let lib_root = root
+    let (mut lib_root, mut bin_root) = match kind {
+        Some(InitKind::Lib) => (Some("src/lib.kn".to_string()), None),
+        Some(InitKind::Bin) => (None, Some("src/main.kn".to_string())),
+        None => ( root
         .join("src/lib.kn")
         .is_file()
-        .then(|| "src/lib.kn".to_string());
-    let mut bin_root = root
+        .then(|| "src/lib.kn".to_string()),
+        root
         .join("src/main.kn")
         .is_file()
-        .then(|| "src/main.kn".to_string());
-    let create_main_stub = lib_root.is_none() && bin_root.is_none();
+        .then(|| "src/main.kn".to_string()))
+    };
+    let create_main_stub = (kind == Some(InitKind::Bin)) && bin_root.is_none();
+    let create_lib_stub = (kind == Some(InitKind::Lib)) && lib_root.is_none();
     if create_main_stub {
         bin_root = Some("src/main.kn".to_string());
+    }
+    if create_lib_stub {
+        lib_root = Some("src/lib.kn".to_string());
     }
 
     Ok(InitPlan {
@@ -1912,6 +1922,7 @@ fn plan_init(root: &Path) -> Result<InitPlan> {
         test_roots: collect_kern_roots(root, "tests")?,
         example_roots: collect_kern_roots(root, "examples")?,
         create_main_stub,
+        create_lib_stub,
     })
 }
 
@@ -1924,6 +1935,14 @@ fn apply_init_plan(root: &Path, init: &InitPlan) -> Result<Vec<PathBuf>> {
         write_if_missing(
             &root.join("src/main.kn"),
             "use std.io;\n\nfn main() i32 {\n    \"Hello, Kern!\".println();\n    return 0;\n}\n",
+            &mut created,
+        )?;
+    }
+
+    if init.create_lib_stub {
+        write_if_missing(
+            &root.join("src/lib.kn"),
+            "use std.io;\n\n pub fn hello() void {\n    \"Hello from lib!\".println();\n}",
             &mut created,
         )?;
     }

--- a/tools/craft/src/cli/commands.rs
+++ b/tools/craft/src/cli/commands.rs
@@ -6,6 +6,7 @@
 
 use crate::analysis_context;
 use crate::build_plan;
+use crate::cli::InitKind;
 use crate::discover;
 use crate::doc;
 use crate::elaborate;
@@ -22,7 +23,6 @@ use crate::resolver;
 use crate::source::{self, FetchProgress, FetchProgressKind, FetchProgressPhase};
 use crate::style;
 use crate::workspace;
-use crate::cli::InitKind;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -148,7 +148,7 @@ pub(super) fn run_command(command: Command) -> Result<()> {
             println!("{}", super::version_text());
             Ok(())
         }
-        Command::Init { path, ui , kind} => run_init(path, ui, kind),
+        Command::Init { path, ui, kind } => run_init(path, ui, kind),
         Command::Clean { path, ui } => run_clean(path, ui),
         Command::Check {
             path,
@@ -1897,17 +1897,20 @@ fn plan_init(root: &Path, kind: Option<InitKind>) -> Result<InitPlan> {
     let (mut lib_root, mut bin_root) = match kind {
         Some(InitKind::Lib) => (Some("src/lib.kn".to_string()), None),
         Some(InitKind::Bin) => (None, Some("src/main.kn".to_string())),
-        None => ( root
-        .join("src/lib.kn")
-        .is_file()
-        .then(|| "src/lib.kn".to_string()),
-        root
-        .join("src/main.kn")
-        .is_file()
-        .then(|| "src/main.kn".to_string()))
+        None => (
+            root.join("src/lib.kn")
+                .is_file()
+                .then(|| "src/lib.kn".to_string()),
+            root.join("src/main.kn")
+                .is_file()
+                .then(|| "src/main.kn".to_string()),
+        ),
     };
-    let create_main_stub = (kind == Some(InitKind::Bin)) && bin_root.is_none();
+    let mut create_main_stub = (kind == Some(InitKind::Bin)) && bin_root.is_none();
     let create_lib_stub = (kind == Some(InitKind::Lib)) && lib_root.is_none();
+    if !create_main_stub && !create_lib_stub && lib_root.is_none() && bin_root.is_none() {
+        create_main_stub = true;
+    }
     if create_main_stub {
         bin_root = Some("src/main.kn".to_string());
     }

--- a/tools/craft/src/cli/tests.rs
+++ b/tools/craft/src/cli/tests.rs
@@ -4,8 +4,8 @@
 //! publish policy, install/uninstall behavior, and subprocess execution paths.
 
 use super::{
-    ColorChoice, Command, HelpTopic, InstallSelection, RunSelection, UiOptions, Verbosity,
-    parse_args, run_command, summarize_check_sources, summarize_source_security,
+    ColorChoice, Command, HelpTopic, InitKind, InstallSelection, RunSelection, UiOptions,
+    Verbosity, parse_args, run_command, summarize_check_sources, summarize_source_security,
     validate_check_source_policy,
 };
 use crate::elaborate::FeatureSelection;
@@ -737,12 +737,67 @@ fn parses_init_with_project_path() {
     .unwrap();
 
     match cmd {
-        Command::Init { path, ui } => {
+        Command::Init { path, ui, kind } => {
             assert_eq!(path.as_deref(), Some(std::path::Path::new("demo")));
             assert_eq!(ui, UiOptions::default());
+            assert_eq!(kind, None);
         }
         other => panic!("expected init command, got {other:?}"),
     }
+}
+
+#[test]
+fn parses_init_with_project_path_and_binary_kind() {
+    let cmd = parse_args([
+        "init".to_string(),
+        "--project-path".to_string(),
+        "demo".to_string(),
+        "--bin".to_string(),
+    ])
+    .unwrap();
+
+    match cmd {
+        Command::Init { path, ui, kind } => {
+            assert_eq!(path.as_deref(), Some(std::path::Path::new("demo")));
+            assert_eq!(ui, UiOptions::default());
+            assert_eq!(kind, Some(InitKind::Bin));
+        }
+        other => panic!("expected init command, got {other:?}"),
+    }
+}
+
+#[test]
+fn parses_init_with_project_path_and_library_kind() {
+    let cmd = parse_args([
+        "init".to_string(),
+        "--project-path".to_string(),
+        "demo".to_string(),
+        "--lib".to_string(),
+    ])
+    .unwrap();
+
+    match cmd {
+        Command::Init { path, ui, kind } => {
+            assert_eq!(path.as_deref(), Some(std::path::Path::new("demo")));
+            assert_eq!(ui, UiOptions::default());
+            assert_eq!(kind, Some(InitKind::Lib));
+        }
+        other => panic!("expected init command, got {other:?}"),
+    }
+}
+
+#[test]
+fn parses_init_with_project_path_and_library_and_both_binary_kind() {
+    let cmd = parse_args([
+        "init".to_string(),
+        "--project-path".to_string(),
+        "demo".to_string(),
+        "--lib".to_string(),
+        "--bin".to_string(),
+    ])
+    .is_err();
+
+    assert!(cmd);
 }
 
 #[test]
@@ -2359,6 +2414,7 @@ fn init_command_scaffolds_minimal_bin_package() {
     run_command(Command::Init {
         path: Some(root.clone()),
         ui: UiOptions::default(),
+        kind: None,
     })
     .unwrap();
 
@@ -2401,6 +2457,7 @@ fn init_command_collects_existing_test_and_example_roots() {
     run_command(Command::Init {
         path: Some(root.clone()),
         ui: UiOptions::default(),
+        kind: None,
     })
     .unwrap();
 


### PR DESCRIPTION
--lib will create a library and --bin will create a binary, it will not break the legacy behavior of `craft init`